### PR TITLE
[RFR] Fix the winner detection when the last move is a winning one

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -37,12 +37,11 @@ export const setMove = (board, player, index) =>
   board.map((item, square) => (square === index ? player : item));
 
 export const getStatusMessage = (board, player) => {
+  const winner = getWinner(board);
+  if (winner) return `${winner} has won the game!`;
+
   if (isTie(board)) return 'It is a tie!';
 
-  const winner = getWinner(board);
-  if (winner) {
-    return `${winner} has won the game!`;
-  }
   return `Player ${player}`;
 };
 


### PR DESCRIPTION
When you play you last move, if it's a winning move the game will display "It's a tie". To fix that, we need to detect if it's a winning play before checking if it's a tie.

## Todo

- [x] Check the tie after checking the winner

**Before**:
![selection_005](https://user-images.githubusercontent.com/5584839/51034330-b52eac00-15a6-11e9-8893-10646778e954.png)

**After**:
![selection_006](https://user-images.githubusercontent.com/5584839/51034823-44888f00-15a8-11e9-9f2a-bc04c2b074f0.png)
